### PR TITLE
Remove incorrect note from download listing example

### DIFF
--- a/5_api/2_sdk/completion.md
+++ b/5_api/2_sdk/completion.md
@@ -38,7 +38,7 @@ Explanation explanation explanation explanation explanation explanation explanat
         import { LMStudioClient } from "@lmstudio/sdk";
 
         const client = new LMStudioClient();
-        const llm = await client.llm.getAny();
+        const llm = await client.llm.model();
         const prediction = llm.complete("My name is");
         for await (const { content } of prediction) {
           process.stdout.write(content);

--- a/5_api/2_sdk/list-local.md
+++ b/5_api/2_sdk/list-local.md
@@ -23,7 +23,6 @@ Explanation explanation explanation explanation explanation explanation explanat
 
         with lmstudio.Client() as client:
             downloaded = client.list_downloaded_models()
-            # NOTE: these don't work yet, but they will work soon
             llm_only = client.llm.list_downloaded()
             embedding_only = client.embedding.list_downloaded()
 


### PR DESCRIPTION
Also rename one last getAny() instance in the TypeScript examples.