### PR TITLE
Move Python cancellation doc

### DIFF
--- a/1_python/1_llm-prediction/cancelling-predictions.md
+++ b/1_python/1_llm-prediction/cancelling-predictions.md
@@ -1,0 +1,58 @@
+---
+title: Cancelling Predictions
+description: Stop an ongoing prediction in `lmstudio-python`
+---
+
+One benefit of using the streaming API is the ability to cancel the
+prediction request based on criteria that can't be represented using
+the `stopStrings` or `maxPredictedTokens` configuration settings.
+
+The following snippet illustrates cancelling the request in response
+to an application specification cancellation condition (such as polling
+an event set by another thread).
+
+```lms_code_snippet
+  variants:
+    "Python (convenience API)":
+      language: python
+      code: |
+        import lmstudio as lms
+        model = lms.llm()
+
+        prediction_stream = model.respond_stream("What is the meaning of life?")
+        cancelled = False
+        for fragment in prediction_stream:
+            if ...: # Cancellation condition will be app specific
+                cancelled = True
+                prediction_stream.cancel()
+                # Note: it is recommended to let the iteration complete,
+                # as doing so allows the partial result to be recorded.
+                # Breaking the loop *is* permitted, but means the partial result
+                # and final prediction stats won't be available to the client
+        # The stream allows the prediction result to be retrieved after iteration
+        if not cancelled:
+            print(prediction_stream.result())
+
+    "Python (scoped resource API)":
+      language: python
+      code: |
+        import lmstudio as lms
+
+        with lms.Client() as client:
+            model = client.llm.model()
+
+            prediction_stream = model.respond_stream("What is the meaning of life?")
+            cancelled = False
+            for fragment in prediction_stream:
+                if ...: # Cancellation condition will be app specific
+                    cancelled = True
+                    prediction_stream.cancel()
+                    # Note: it is recommended to let the iteration complete,
+                    # as doing so allows the partial result to be recorded.
+                    # Breaking the loop *is* permitted, but means the partial result
+                    # and final prediction stats won't be available to the client
+            # The stream allows the prediction result to be retrieved after iteration
+            if not cancelled:
+                print(prediction_stream.result())
+
+```

--- a/1_python/1_llm-prediction/chat-completion.md
+++ b/1_python/1_llm-prediction/chat-completion.md
@@ -60,6 +60,9 @@ entire response to be generated before displaying anything).
 
 ```
 
+## Cancelling a Chat Response
+
+See the [Cancelling a Prediction](./cancelling-predictions) section for how to cancel a prediction in progress.
 
 ## Obtain a Model
 
@@ -275,10 +278,10 @@ that receives a float from 0.0-1.0 representing prompt processing progress.
 
 In addition to `on_prompt_processing_progress`, the other available progress callbacks are:
 
-* `on_first_token`: called after prompt processing is complete and the first token is being emitted.
+- `on_first_token`: called after prompt processing is complete and the first token is being emitted.
   Does not receive any arguments (use the streaming iteration API or `on_prediction_fragment`
   to process tokens as they are emitted).
-* `on_prediction_fragment`: called for each prediction fragment received by the client.
+- `on_prediction_fragment`: called for each prediction fragment received by the client.
   Receives the same prediction fragments as iterating over the stream iteration API.
-* `on_message`: called with an assistant response message when the prediction is complete.
+- `on_message`: called with an assistant response message when the prediction is complete.
   Intended for appending received messages to a chat history instance.

--- a/1_python/1_llm-prediction/chat-completion.md
+++ b/1_python/1_llm-prediction/chat-completion.md
@@ -60,61 +60,6 @@ entire response to be generated before displaying anything).
 
 ```
 
-## Cancelling a Chat Response
-
-One benefit of using the streaming API is the ability to cancel the
-prediction request based on criteria that can't be represented using
-the `stopStrings` or `maxPredictedTokens` configuration settings.
-
-The following snippet illustrates cancelling the request in response
-to an application specification cancellation condition (such as polling
-an event set by another thread).
-
-```lms_code_snippet
-  variants:
-    "Python (convenience API)":
-      language: python
-      code: |
-        import lmstudio as lms
-        model = lms.llm()
-
-        prediction_stream = model.respond_stream("What is the meaning of life?")
-        cancelled = False
-        for fragment in prediction_stream:
-            if ...: # Cancellation condition will be app specific
-                cancelled = True
-                prediction_stream.cancel()
-                # Note: it is recommended to let the iteration complete,
-                # as doing so allows the partial result to be recorded.
-                # Breaking the loop *is* permitted, but means the partial result
-                # and final prediction stats won't be available to the client
-        # The stream allows the prediction result to be retrieved after iteration
-        if not cancelled:
-            print(prediction_stream.result())
-
-    "Python (scoped resource API)":
-      language: python
-      code: |
-        import lmstudio as lms
-
-        with lms.Client() as client:
-            model = client.llm.model()
-
-            prediction_stream = model.respond_stream("What is the meaning of life?")
-            cancelled = False
-            for fragment in prediction_stream:
-                if ...: # Cancellation condition will be app specific
-                    cancelled = True
-                    prediction_stream.cancel()
-                    # Note: it is recommended to let the iteration complete,
-                    # as doing so allows the partial result to be recorded.
-                    # Breaking the loop *is* permitted, but means the partial result
-                    # and final prediction stats won't be available to the client
-            # The stream allows the prediction result to be retrieved after iteration
-            if not cancelled:
-                print(prediction_stream.result())
-
-```
 
 ## Obtain a Model
 


### PR DESCRIPTION
## Summary
- extract "Cancelling a Chat Response" from Python chat completion page
- create `cancelling-predictions.md` article under Python LLM prediction

## Testing
- `git status --short`