### PR TITLE
docs: fix REST API link.

### DIFF
--- a/0_app/4_api/index.md
+++ b/0_app/4_api/index.md
@@ -6,7 +6,7 @@ description: Run an LLM API server on localhost with LM Studio
 
 You can serve local LLMs from LM Studio's Developer tab, either on localhost or on the network.
 
-LM Studio's APIs can be used through an [OpenAI compatibility mode](/docs/app/api/endpoints/openai), enhanced [REST API](/docs/api/rest-api/endpoints/rest), or through a client library like [lmstudio-js](/docs/api/sdk).
+LM Studio's APIs can be used through an [OpenAI compatibility mode](/docs/app/api/endpoints/openai), enhanced [REST API](/docs/app/api/endpoints/rest), or through a client library like [lmstudio-js](/docs/api/sdk).
 
 #### API options
 


### PR DESCRIPTION
The current link in https://lmstudio.ai/docs/app/api contains a reference to the REST API:
<img width="695" height="270" alt="image" src="https://github.com/user-attachments/assets/1e65788f-aa5f-4380-a623-c3fb8887eb18" />

When you click on this link, you have an error:
<img width="1699" height="1048" alt="image" src="https://github.com/user-attachments/assets/7da932df-33e2-418c-a939-be68bdcdaf71" />

I believe the correct link now is:
<img width="1626" height="1359" alt="image" src="https://github.com/user-attachments/assets/2a19e682-9721-44a4-b775-f1b1a374891c" />


Hence this fix.
This fixes issue #68 