### PR TITLE
granite-4-micro model of choice

### DIFF
--- a/1_developer/0_core/_authentication.md
+++ b/1_developer/0_core/_authentication.md
@@ -55,7 +55,7 @@ curl -X POST \
   -H 'Authorization: Bearer $LM_API_TOKEN' \
   -H 'Content-Type: application/json' \
   -d '{
-    "model": "qwen/qwen3-8b",
+    "model": "ibm/granite-4-micro",
     "input": "What is the first line in the tiktoken documentation?",
     "integrations": [
       {

--- a/1_developer/0_core/_mcp.md
+++ b/1_developer/0_core/_mcp.md
@@ -68,13 +68,14 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "What is the top trending model on hugging face?",
           "integrations": [
             {
               "type": "ephemeral_mcp",
               "server_label": "huggingface",
-              "server_url": "https://huggingface.co/mcp"
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"]
             }
           ],
           "context_length": 8000
@@ -84,27 +85,29 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-              },
-              json={
-                  "model": "qwen/qwen3-8b",
-                  "input": "What is the top trending model on hugging face?",
-                  "integrations": [
-                      {
-                          "type": "ephemeral_mcp",
-                          "server_label": "huggingface",
-                          "server_url": "https://huggingface.co/mcp"
-                      }
-                  ],
-                  "context_length": 8000
-              }
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "What is the top trending model on hugging face?",
+          "integrations": [
+            {
+              "type": "ephemeral_mcp",
+              "server_label": "huggingface",
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"]
+            }
+          ],
+          "context_length": 8000
+        }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -115,13 +118,14 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "What is the top trending model on hugging face?",
           "integrations": [
             {
               "type": "ephemeral_mcp",
               "server_label": "huggingface",
-              "server_url": "https://huggingface.co/mcp"
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"]
             }
           ],
           "context_length": 8000
@@ -138,7 +142,7 @@ variants:
     language: json
     code: |
       {
-        "model_instance_id": "qwen/qwen3-8b",
+        "model_instance_id": "ibm/granite-4-micro",
         "output": [
           {
             "type": "reasoning",
@@ -201,8 +205,8 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
-          "input": "Open this link https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          "model": "ibm/granite-4-micro",
+          "input": "Open lmstudio.ai",
           "integrations": ["mcp/playwright"],
           "context_length": 8000,
           "temperature": 0
@@ -212,22 +216,23 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={
-              "model": "qwen/qwen3-8b",
-              "input": "Open this link https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-              "integrations": ["mcp/playwright"],
-              "context_length": 8000,
-              "temperature": 0
-          }
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "Open lmstudio.ai",
+          "integrations": ["mcp/playwright"],
+          "context_length": 8000,
+          "temperature": 0
+        }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -238,8 +243,8 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b",
-          input: "Open this link https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          model: "ibm/granite-4-micro",
+          input: "Open lmstudio.ai",
           integrations: ["mcp/playwright"],
           context_length: 8000,
           temperature: 0
@@ -257,7 +262,7 @@ variants:
     language: json
     code: |
       {
-        "model_instance_id": "qwen/qwen3-8b",
+        "model_instance_id": "ibm/granite-4-micro",
         "output": [
           {
             "type": "reasoning",
@@ -312,7 +317,7 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "What is the top trending model on hugging face?",
           "integrations": [
             {
@@ -329,28 +334,29 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={
-              "model": "qwen/qwen3-8b",
-              "input": "What is the top trending model on hugging face?",
-              "integrations": [
-                  {
-                      "type": "ephemeral_mcp",
-                      "server_label": "huggingface",
-                      "server_url": "https://huggingface.co/mcp",
-                      "allowed_tools": ["model_search"]
-                  }
-              ],
-              "context_length": 8000
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "What is the top trending model on hugging face?",
+          "integrations": [
+            {
+              "type": "ephemeral_mcp",
+              "server_label": "huggingface",
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"]
+            }
+          ],
+          "context_length": 8000
         }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -361,7 +367,7 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b",
+          model: "ibm/granite-4-micro",
           input: "What is the top trending model on hugging face?",
           integrations: [
             {
@@ -393,7 +399,7 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "Give me details about my SUPER-SECRET-PRIVATE Hugging face model",
           "integrations": [
             {
@@ -413,31 +419,32 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={
-              "model": "qwen/qwen3-8b",
-              "input": "Give me details about my SUPER-SECRET-PRIVATE Hugging face model",
-              "integrations": [
-                  {
-                      "type": "ephemeral_mcp",
-                      "server_label": "huggingface",
-                      "server_url": "https://huggingface.co/mcp",
-                      "allowed_tools": ["model_search"],
-                      "headers": {
-                          "Authorization": "Bearer <YOUR_HF_TOKEN>"
-                      }
-                  }
-              ],
-              "context_length": 8000
-          }
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "Give me details about my SUPER-SECRET-PRIVATE Hugging face model",
+          "integrations": [
+            {
+              "type": "ephemeral_mcp",
+              "server_label": "huggingface",
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"],
+              "headers": {
+                "Authorization": "Bearer <YOUR_HF_TOKEN>"
+              }
+            }
+          ],
+          "context_length": 8000
+        }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -448,7 +455,7 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b",
+          model: "ibm/granite-4-micro",
           input: "Give me details about my SUPER-SECRET-PRIVATE Hugging face model",
           integrations: [
             {

--- a/1_developer/_2_rest/chat.md
+++ b/1_developer/_2_rest/chat.md
@@ -131,7 +131,7 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "Tell me the top trending model on hugging face and navigate to https://lmstudio.ai",
           "integrations": [
             {

--- a/1_developer/_2_rest/download.md
+++ b/1_developer/_2_rest/download.md
@@ -32,7 +32,7 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-4b-2507"
+          "model": "ibm/granite-4-micro"
         }'
 ```
 ````

--- a/1_developer/_2_rest/quickstart.md
+++ b/1_developer/_2_rest/quickstart.md
@@ -21,7 +21,7 @@ By default, the server is available at `http://localhost:1234`.
 If you don't have a model downloaded yet, you can download the model:
 
 ```bash
-lms get qwen/qwen3-8b
+lms get ibm/granite-4-micro
 ```
 
 
@@ -47,7 +47,7 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "Write a short haiku about sunrise."
         }'
   Python:
@@ -55,19 +55,20 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={
-              "model": "qwen/qwen3-8b",
-              "input": "Write a short haiku about sunrise."
-          }
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "Write a short haiku about sunrise."
+        }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -78,7 +79,7 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b",
+          model: "ibm/granite-4-micro",
           input: "Write a short haiku about sunrise."
         })
       });
@@ -102,13 +103,14 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "What is the top trending model on hugging face?",
           "integrations": [
             {
               "type": "ephemeral_mcp",
               "server_label": "huggingface",
-              "server_url": "https://huggingface.co/mcp"
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"]
             }
           ],
           "context_length": 8000
@@ -118,27 +120,29 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={
-              "model": "qwen/qwen3-8b",
-              "input": "What is the top trending model on hugging face?",
-              "integrations": [
-                  {
-                      "type": "ephemeral_mcp",
-                      "server_label": "huggingface",
-                      "server_url": "https://huggingface.co/mcp"
-                  }
-              ],
-              "context_length": 8000
-          }
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "What is the top trending model on hugging face?",
+          "integrations": [
+            {
+              "type": "ephemeral_mcp",
+              "server_label": "huggingface",
+              "server_url": "https://huggingface.co/mcp",
+              "allowed_tools": ["model_search"]
+            }
+          ],
+          "context_length": 8000
+        }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -149,13 +153,14 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b",
+          model: "ibm/granite-4-micro",
           input: "What is the top trending model on hugging face?",
           integrations: [
             {
               type: "ephemeral_mcp",
               server_label: "huggingface",
-              server_url: "https://huggingface.co/mcp"
+              server_url: "https://huggingface.co/mcp",
+              allowed_tools: ["model_search"]
             }
           ],
           context_length: 8000
@@ -175,12 +180,13 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
-          "input": "Open this link https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          "model": "ibm/granite-4-micro",
+          "input": "Open lmstudio.ai",
           "integrations": [
             {
               "type": "plugin",
-              "id": "mcp/playwright"
+              "id": "mcp/playwright",
+              "allowed_tools": ["browser_navigate"]
             }
           ],
           "context_length": 8000
@@ -190,26 +196,28 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/chat",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={
-              "model": "qwen/qwen3-8b",
-              "input": "Open this link https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-              "integrations": [
-                  {
-                      "type": "plugin",
-                      "id": "mcp/playwright"
-                  }
-              ],
-              "context_length": 8000
+        "http://localhost:1234/api/v1/chat",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={
+          "model": "ibm/granite-4-micro",
+          "input": "Open lmstudio.ai",
+          "integrations": [
+            {
+              "type": "plugin",
+              "id": "mcp/playwright".
+              "allowed_tools": ["browser_navigate"]
+            }
+          ],
+          "context_length": 8000
         }
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -220,12 +228,13 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b",
-          input: "Open this link https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          model: "ibm/granite-4-micro",
+          input: "Open lmstudio.ai",
           integrations: [
             {
               type: "plugin",
-              id: "mcp/playwright"
+              id: "mcp/playwright",
+              allowed_tools: ["browser_navigate"]
             }
           ],
           context_length: 8000
@@ -250,23 +259,24 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b"
+          "model": "ibm/granite-4-micro"
         }'
   Python:
     language: python
     code: |
       import os
       import requests
+      import json
 
       response = requests.post(
-          "http://localhost:1234/api/v1/models/download",
-          headers={
-              "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
-              "Content-Type": "application/json"
-          },
-          json={"model": "qwen/qwen3-8b"}
+        "http://localhost:1234/api/v1/models/download",
+        headers={
+          "Authorization": f"Bearer {os.environ['LM_API_TOKEN']}",
+          "Content-Type": "application/json"
+        },
+        json={"model": "ibm/granite-4-micro"}
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |
@@ -277,7 +287,7 @@ variants:
           "Content-Type": "application/json"
         },
         body: JSON.stringify({
-          model: "qwen/qwen3-8b"
+          model: "ibm/granite-4-micro"
         })
       });
       const data = await response.json();
@@ -298,13 +308,14 @@ variants:
     code: |
       import os
       import requests
+      import json
 
       job_id = "your-job-id"
       response = requests.get(
-          f"http://localhost:1234/api/v1/models/download/status/{job_id}",
-          headers={"Authorization": f"Bearer {os.environ['LM_API_TOKEN']}"}
+        f"http://localhost:1234/api/v1/models/download/status/{job_id}",
+        headers={"Authorization": f"Bearer {os.environ['LM_API_TOKEN']}"}
       )
-      print(response.json())
+      print(json.dumps(response.json(), indent=2))
   TypeScript:
     language: typescript
     code: |

--- a/1_developer/_2_rest/stateful-chats.md
+++ b/1_developer/_2_rest/stateful-chats.md
@@ -17,14 +17,12 @@ variants:
   curl:
     language: bash
     code: |
-      # store is true by default
       curl http://localhost:1234/api/v1/chat \
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
-          "input": "My favorite color is blue.",
-          "store": true
+          "model": "ibm/granite-4-micro",
+          "input": "My favorite color is blue."
         }'
 ```
 
@@ -41,7 +39,7 @@ variants:
     language: json
     code: |
       {
-        "model_instance_id": "qwen/qwen3-8b",
+        "model_instance_id": "ibm/granite-4-micro",
         "output": [
           {
             "type": "message",
@@ -64,15 +62,13 @@ variants:
   curl:
     language: bash
     code: |
-      # store is true by default
       curl http://localhost:1234/api/v1/chat \
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "What color did I just mention?",
-          "previous_response_id": "resp_abc123xyz...",
-          "store": true
+          "previous_response_id": "resp_abc123xyz..."
         }'
 ```
 
@@ -92,7 +88,7 @@ variants:
         -H "Authorization: Bearer $LM_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-          "model": "qwen/qwen3-8b",
+          "model": "ibm/granite-4-micro",
           "input": "Tell me a joke.",
           "store": false
         }'


### PR DESCRIPTION
Idea is to make our copy-paste examples as accessible and responsive as possible, on a variety of hardware. `ibm/granite-4-micro` achieves this while still being able to call MCPs successfully.

(I also normalized all indents to 2 rather than 4 in code snippets so that examples are more compact on whatever size window)

On Macbook M3 Pro 36GB for request:
```
-> % curl http://localhost:1234/api/v1/chat \
  -H "Authorization: Bearer $LM_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "model": *
    "input": "What is the top trending model on hugging face?",
    "integrations": [
      {
        "type": "ephemeral_mcp",
        "server_label": "huggingface",
        "server_url": "https://huggingface.co/mcp",
        "allowed_tools": ["model_search"]
      }
    ],
    "context_length": 8000
  }'
```
**ibm/granite-4-micro**
- Load size in RAM: 2.76GB
- "total_output_tokens": 144
- "tokens_per_second": 41.21414059718914
- "time_to_first_token_seconds": 0.879

**qwen/qwen3-8b**
- Load size in RAM: 4.69GB
- "total_output_tokens": 355
- "tokens_per_second": 26.623343426572564
- "time_to_first_token_seconds": 1.62