### PR TITLE
Fix typo in Ministral MLX entry

### DIFF
--- a/1_developer/3_openai-compat/tools.md
+++ b/1_developer/3_openai-compat/tools.md
@@ -258,7 +258,7 @@ Models that currently have native tool use support in LM Studio (subject to chan
   - `MLX` [mlx-community/Meta-Llama-3.1-8B-Instruct-8bit](https://model.lmstudio.ai/download/mlx-community/Meta-Llama-3.1-8B-Instruct-8bit) (8.54 GB)
 - Mistral
   - `GGUF` [bartowski/Ministral-8B-Instruct-2410-GGUF](https://model.lmstudio.ai/download/bartowski/Ministral-8B-Instruct-2410-GGUF) (4.67 GB)
-  - `MLX` [mlx-community/Ministral-8B-Instruct-2410-4bit](https://model.lmstudio.ai/download/mlx-community/Ministral-8B-Instruct-2410-4bit) (4.67 GB GB)
+  - `MLX` [mlx-community/Ministral-8B-Instruct-2410-4bit](https://model.lmstudio.ai/download/mlx-community/Ministral-8B-Instruct-2410-4bit) (4.67 GB)
 
 ### Default tool use support
 


### PR DESCRIPTION
Removed duplicate 'GB' in the MLX entry for Ministral.