### PR TITLE
Llmster Headless

### DIFF
--- a/1_developer/0_core/headless_llmster.md
+++ b/1_developer/0_core/headless_llmster.md
@@ -1,13 +1,19 @@
 ---
 title: "Setup llmster as a Startup Task on Linux"
 sidebar_title: "Linux Startup Task"
-description: "TODO"
+description: "Configure llmster to run on startup using systemctl on Linux"
 index: 3
 ---
 
-`llmster`, LM Studio's headless daemon, can be configured to run on startup. Follow this doc to learn how to set up `llmster` to launch, load a model, and start an HTTP server on startup using `systemctl` on Linux.
+`llmster`, LM Studio's headless daemon, can be configured to run on startup. This guide covers setting up `llmster` to launch, load a model, and start an HTTP server automatically using `systemctl` on Linux.
 
-## 1. Install the Daemon
+```lms_info
+This guide is for Linux systems without a graphical interface. For machines with a GUI, you can configure LM Studio to [run as a service on login](/docs/developer/core/headless) instead.
+```
+
+## Install the Daemon
+
+Run the following command to install `llmster`:
 
 ```bash
 curl -fsSL https://lmstudio.ai/install.sh | bash
@@ -19,7 +25,9 @@ Verify the installation:
 lms --help
 ```
 
-## 2. Download a Model
+## Download a Model
+
+Download a model to use with the server:
 
 ```bash
 lms get openai/gpt-oss-20b
@@ -27,7 +35,7 @@ lms get openai/gpt-oss-20b
 
 The output will show the model path. You'll need this for the systemd configuration.
 
-## 3. Manual Test
+## Manual Test
 
 Before configuring systemd, verify everything works manually.
 
@@ -55,7 +63,7 @@ Stop the server when done testing:
 lms server stop
 ```
 
-## 4. Create Systemd Service
+## Create Systemd Service
 
 Create `/etc/systemd/system/lmstudio.service`. Replace `YOUR_USERNAME` with your username.
 
@@ -79,7 +87,7 @@ WantedBy=multi-user.target
 
 This unit automatically loads the `openai/gpt-oss-20b` model on startup. Alternatively, you can avoid loading a specific model on startup and instead rely on [Just-In-Time (JIT) loading and Eviction](/docs/developer/core/ttl-and-auto-evict) in the server.
 
-## 5. Enable and Start the Service
+## Enable and Start the Service
 
 ```bash
 sudo systemctl daemon-reload
@@ -87,7 +95,7 @@ sudo systemctl enable lmstudio.service
 sudo systemctl start lmstudio.service
 ```
 
-## 6. Verify
+## Verify
 
 Check the service status:
 
@@ -113,3 +121,9 @@ sudo systemctl restart lmstudio
 # Disable auto-start
 sudo systemctl disable lmstudio
 ```
+
+## Community
+
+Chat with other LM Studio developers, discuss LLMs, hardware, and more on the [LM Studio Discord server](https://discord.gg/aPQfnNkxGC).
+
+Please report bugs and issues in the [lmstudio-bug-tracker](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues) GitHub repository.


### PR DESCRIPTION
I created this as a separate doc from the existing GUI Headless doc because the standalone `llmster` daemon is new and has a different configuration method. This method is only applicable to Linux currently.