### PR TITLE
Add LM Studio vs llmster vs lms guide + MCP OAuth section

### DIFF
--- a/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
+++ b/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
@@ -1,0 +1,77 @@
+---
+title: LM Studio vs llmster vs lms
+description: Understand the differences between the LM Studio app, llmster, and lms
+index: 5
+---
+
+## LM Studio app, llmster, and lms
+
+The LM Studio app, llmster, and `lms` are three distinct yet closely related components in LM Studio. Each serves a different purpose while all sharing the same underlying engine and functionalities.
+
+## LM Studio (the desktop app)
+
+The LM Studio app is a user-friendly graphical interface containing the full capabilities of LM Studio.
+
+### Notable capabilities:
+
+- Search and download models from Hugging Face
+- Chat with models through a built-in chat interface
+- Upload and chat documents (RAG)
+- Configure model settings, prompt templates, and presets
+- Run a local server with through native REST APIs or OpenAI/Anthropic compatible endpoints
+- Connect MCP servers and use them with local models
+
+The desktop app is the easiest starting point if you're new to running models locally or prefer a graphical interface.
+
+## llmster (the headless daemon)
+
+llmster is LM Studio’s headless daemon – a standalone background service that can run without a GUI. This means you do not have to download the LM Studio app to use llmster via the terminal.
+
+llmster becomes useful when you need to run LM Studio:
+- On a Linux server or cloud instance
+- On a GPU rig without a screen or display
+- In a CI/CD pipeline
+- As a background service that starts on machine boot
+And more!
+
+Because llmster runs independently of the desktop app, you can get the full model-serving capabilities of LM Studio in environments where installing or launching a GUI application isn't practical.
+
+Learn more and install llmster [here](https://lmstudio.ai/docs/developer/core/headless)
+
+**Common commands:**
+
+```bash
+lms daemon up      # Start llmster
+lms daemon status  # Check if the daemon is running
+```
+
+## lms (the CLI)
+
+`lms` is LM Studio's CLI (command-line interface). It lets you interact with LM Studio and manage your models directly from a terminal. 
+
+`lms` is included automatically upon downloading the app or llmster.
+
+**Common commands:**
+
+```bash
+lms get <model>        # Download a model
+lms load <model>       # Load a model into memory
+lms ls                 # List models available on disk
+lms server start       # Start the local HTTP server
+lms chat               # Start an interactive chat session in the terminal
+lms log stream         # Stream incoming and outgoing request logs
+```
+
+If LM Studio isn't already running when you run an `lms` command, it will start running automatically.
+
+**Example commands to download and serve a model:**
+
+```bash
+lms get openai/gpt-oss-20b
+lms load openai/gpt-oss-20b
+lms server start
+```
+
+Once the server is running, it listens on http://localhost:1234. Point any SDK or compatible tool at our OpenAI or Anthropic-compatible endpoints to use your LM Studio models.
+
+In short, all three operate on the same running instance and can be used simultaneously. `lms` is the command-line tool to talk to both, whether you're running the desktop app, llmster headlessly, or both at once.

--- a/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
+++ b/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
@@ -47,7 +47,7 @@ lms daemon status  # Check if the daemon is running
 
 ## lms (the CLI)
 
-`lms` is LM Studio's CLI (command-line interface). It lets you interact with LM Studio and manage your models directly from a terminal. 
+`lms` is LM Studio's CLI (command-line interface). It lets you interact with both the LM Studio desktop app and llmster, and manage your models directly from a terminal. 
 
 `lms` is included automatically upon downloading the app or llmster.
 

--- a/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
+++ b/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
@@ -1,5 +1,5 @@
 ---
-title: LM Studio vs llmster vs lms
+title: LM Studio, llmster, and lms
 description: Understand the differences between the LM Studio app, llmster, and lms
 index: 5
 ---

--- a/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
+++ b/0_app/1_basics/lmstudio-vs-llmster-vs-lms.md
@@ -6,7 +6,7 @@ index: 5
 
 ## LM Studio app, llmster, and lms
 
-The LM Studio app, llmster, and `lms` are three distinct yet closely related components in LM Studio. Each serves a different purpose while all sharing the same underlying engine and functionalities.
+The LM Studio app, llmster, and `lms` are three different tools offered by LM Studio to make use of local AI easy and accessible.
 
 ## LM Studio (the desktop app)
 
@@ -38,13 +38,6 @@ Because llmster runs independently of the desktop app, you can get the full mode
 
 Learn more and install llmster [here](https://lmstudio.ai/docs/developer/core/headless)
 
-**Common commands:**
-
-```bash
-lms daemon up      # Start llmster
-lms daemon status  # Check if the daemon is running
-```
-
 ## lms (the CLI)
 
 `lms` is LM Studio's CLI (command-line interface). It lets you interact with both the LM Studio desktop app and llmster, and manage your models directly from a terminal. 
@@ -74,4 +67,4 @@ lms server start
 
 Once the server is running, it listens on http://localhost:1234. Point any SDK or compatible tool at our OpenAI or Anthropic-compatible endpoints to use your LM Studio models.
 
-In short, all three operate on the same running instance and can be used simultaneously. `lms` is the command-line tool to talk to both, whether you're running the desktop app, llmster headlessly, or both at once.
+In short, `lms` is the command-line tool to talk to both, the desktop app or llmster.

--- a/1_developer/2_rest/list.md
+++ b/1_developer/2_rest/list.md
@@ -138,80 +138,88 @@ variants:
         "models": [
           {
             "type": "llm",
-            "publisher": "lmstudio-community",
-            "key": "gemma-3-270m-it-qat",
-            "display_name": "Gemma 3 270m Instruct Qat",
-            "architecture": "gemma3",
-            "quantization": {
-              "name": "Q4_0",
-              "bits_per_weight": 4
-            },
-            "size_bytes": 241410208,
-            "params_string": "270M",
-            "loaded_instances": [
-              {
-                "id": "gemma-3-270m-it-qat",
-                "config": {
-                  "context_length": 4096,
-                  "eval_batch_size": 512,
-                  "flash_attention": false,
-                  "num_experts": 0,
-                  "offload_kv_cache_to_gpu": true
-                }
-              }
-            ],
-            "max_context_length": 32768,
-            "format": "gguf",
-            "capabilities": {
-              "vision": false,
-              "trained_for_tool_use": false,
-              "reasoning": {
-                "allowed_options": ["off", "on"],
-                "default": "on"
-              }
-            },
-            "description": null
-          },
-          {
-            "type": "llm",
-            "publisher": "deepseek",
-            "key": "deepseek-r1",
-            "display_name": "DeepSeek R1",
-            "architecture": "deepseek",
+            "publisher": "google",
+            "key": "google/gemma-4-26b-a4b",
+            "display_name": "Gemma 4 26B A4B",
+            "architecture": "gemma4",
             "quantization": {
               "name": "Q4_K_M",
               "bits_per_weight": 4
             },
-            "size_bytes": 40492610355,
-            "params_string": "671B",
-            "loaded_instances": [],
-            "max_context_length": 131072,
+            "size_bytes": 17990911801,
+            "params_string": "26B-A4B",
+            "loaded_instances": [
+              {
+                "id": "google/gemma-4-26b-a4b",
+                "config": {
+                  "context_length": 4096,
+                  "eval_batch_size": 512,
+                  "parallel": 4,
+                  "flash_attention": true,
+                  "num_experts": 8,
+                  "offload_kv_cache_to_gpu": true
+                }
+              }
+            ],
+            "max_context_length": 262144,
             "format": "gguf",
             "capabilities": {
-              "vision": false,
+              "vision": true,
               "trained_for_tool_use": true,
               "reasoning": {
-                "allowed_options": ["on"],
+                "allowed_options": [
+                  "off",
+                  "on"
+                ],
                 "default": "on"
               }
             },
-            "description": null
+            "description": null,
+            "variants": [
+              "google/gemma-4-26b-a4b@q4_k_m"
+            ],
+            "selected_variant": "google/gemma-4-26b-a4b@q4_k_m"
           },
-          {
-            "type": "embedding",
-            "publisher": "gaianet",
-            "key": "text-embedding-nomic-embed-text-v1.5-embedding",
-            "display_name": "Nomic Embed Text v1.5",
-            "quantization": {
-              "name": "F16",
-              "bits_per_weight": 16
+            {
+              "type": "llm",
+              "publisher": "deepseek",
+              "key": "deepseek-r1",
+              "display_name": "DeepSeek R1",
+              "architecture": "deepseek",
+              "quantization": {
+                "name": "Q4_K_M",
+                "bits_per_weight": 4
+              },
+              "size_bytes": 40492610355,
+              "params_string": "671B",
+              "loaded_instances": [],
+              "max_context_length": 131072,
+              "format": "gguf",
+              "capabilities": {
+                "vision": false,
+                "trained_for_tool_use": true,
+                "reasoning": {
+                  "allowed_options": ["on"],
+                  "default": "on"
+                }
+              },
+              "description": null
             },
-            "size_bytes": 274290560,
-            "params_string": null,
-            "loaded_instances": [],
-            "max_context_length": 2048,
-            "format": "gguf"
-          }
+            {
+              "type": "embedding",
+              "publisher": "gaianet",
+              "key": "text-embedding-nomic-embed-text-v1.5-embedding",
+              "display_name": "Nomic Embed Text v1.5",
+              "quantization": {
+                "name": "F16",
+                "bits_per_weight": 16
+              },
+              "size_bytes": 274290560,
+              "params_string": null,
+              "loaded_instances": [],
+              "max_context_length": 2048,
+              "format": "gguf"
+            }
         ]
       }
 ```

--- a/1_developer/2_rest/list.md
+++ b/1_developer/2_rest/list.md
@@ -174,11 +174,7 @@ variants:
                 "default": "on"
               }
             },
-            "description": null,
-            "variants": [
-              "google/gemma-4-26b-a4b@q4_k_m"
-            ],
-            "selected_variant": "google/gemma-4-26b-a4b@q4_k_m"
+            "description": null
           },
             {
               "type": "llm",

--- a/1_developer/2_rest/list.md
+++ b/1_developer/2_rest/list.md
@@ -111,6 +111,17 @@ variants:
         - name: trained_for_tool_use
           type: boolean
           description: Whether the model was trained for tool/function calling.
+        - name: reasoning
+          type: object
+          optional: true
+          description: Public reasoning configuration for the model. Absent when no reasoning config is exposed.
+          children:
+            - name: allowed_options
+              type: '("off" | "on" | "low" | "medium" | "high")[]'
+              description: Allowed public reasoning settings for the model.
+            - name: default
+              type: '"off" | "on" | "low" | "medium" | "high"'
+              description: Default public reasoning setting for the model.
     - name: description
       type: string | null
       optional: true
@@ -153,7 +164,36 @@ variants:
             "format": "gguf",
             "capabilities": {
               "vision": false,
-              "trained_for_tool_use": false
+              "trained_for_tool_use": false,
+              "reasoning": {
+                "allowed_options": ["off", "on"],
+                "default": "on"
+              }
+            },
+            "description": null
+          },
+          {
+            "type": "llm",
+            "publisher": "deepseek",
+            "key": "deepseek-r1",
+            "display_name": "DeepSeek R1",
+            "architecture": "deepseek",
+            "quantization": {
+              "name": "Q4_K_M",
+              "bits_per_weight": 4
+            },
+            "size_bytes": 40492610355,
+            "params_string": "671B",
+            "loaded_instances": [],
+            "max_context_length": 131072,
+            "format": "gguf",
+            "capabilities": {
+              "vision": false,
+              "trained_for_tool_use": true,
+              "reasoning": {
+                "allowed_options": ["on"],
+                "default": "on"
+              }
             },
             "description": null
           },

--- a/1_developer/2_rest/list.md
+++ b/1_developer/2_rest/list.md
@@ -190,7 +190,7 @@ variants:
             "variants": [
               "google/gemma-4-26b-a4b@q4_k_m"
             ],
-            "selected_variant": "google/gemma-4-26b-a4b@q4_k_m"dd
+            "selected_variant": "google/gemma-4-26b-a4b@q4_k_m"
           },
             {
               "type": "llm",

--- a/1_developer/2_rest/list.md
+++ b/1_developer/2_rest/list.md
@@ -82,6 +82,10 @@ variants:
               type: number
               optional: true
               description: Number of input tokens to process together in a single batch during evaluation. Absent for embedding models.
+            - name: parallel
+              type: number
+              optional: true
+              description: Maximum number of parallel predictions the instance can handle. Absent for embedding models.
             - name: flash_attention
               type: boolean
               optional: true
@@ -126,6 +130,14 @@ variants:
       type: string | null
       optional: true
       description: Model description. Absent for embedding models.
+    - name: variants
+      type: array
+      optional: true
+      description: List of available quantization variant names for this model. Present for multi-variant models.
+    - name: selected_variant
+      type: string
+      optional: true
+      description: The currently selected variant name. Present when `variants` is present.
 ```
 :::split:::
 ```lms_code_snippet
@@ -174,7 +186,11 @@ variants:
                 "default": "on"
               }
             },
-            "description": null
+            "description": null,
+            "variants": [
+              "google/gemma-4-26b-a4b@q4_k_m"
+            ],
+            "selected_variant": "google/gemma-4-26b-a4b@q4_k_m"dd
           },
             {
               "type": "llm",

--- a/4_integrations/1_mcp-remote/index.md
+++ b/4_integrations/1_mcp-remote/index.md
@@ -25,7 +25,12 @@ From that point on, your model can call tools from that service just like any ot
 
 Some services require you to bring your own OAuth app, either because they don't support dynamic client registration, or because they need a specific redirect URL whitelisted in their developer portal.
 
-In these cases, add an `auth` object to the server entry in `mcp.json`:
+In these cases, add an `auth` object to the server entry in `mcp.json`. When configuring your OAuth app, use the following callback URL:
+
+```
+http://127.0.0.1:33389/mcp-oauth-callback
+```
+
 
 ```json
 {

--- a/4_integrations/1_mcp-remote/index.md
+++ b/4_integrations/1_mcp-remote/index.md
@@ -1,0 +1,42 @@
+---
+title: MCP Integrations
+sidebar_title: Introduction
+description: Connect external services to LM Studio via MCP.
+index: 1
+---
+
+LM Studio now support MCP that use OAuth, letting you connect integrations that require authentication, no tokens to copy, no headers to configure. LM Studio opens a browser window, you log in, and the integration's tools become available to your models.
+
+<img src="/assets/docs/mcp-auth.webp" style="width: 100%;" data-caption="Atlassian MCP logged in and Notion MCP requiring authentication" />
+
+## How it works
+
+When you add an OAuth-backed MCP integration, LM Studio:
+
+1. Opens a browser window to the service's authorization page
+2. Stores the token securely after you approve access
+3. Makes the server's tools available in chat
+
+From that point on, your model can call tools from that service just like any other MCP server.
+
+---
+
+## Connecting with your own OAuth credentials
+
+Some services require you to bring your own OAuth app, either because they don't support dynamic client registration, or because they need a specific redirect URL whitelisted in their developer portal.
+
+In these cases, add an `auth` object to the server entry in `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "oauth-server": {
+      "url": "https://api.example.com/mcp",
+      "auth": {
+        "CLIENT_ID": "TEST_CLIENT_ID",
+        "CLIENT_SECRET": "TEST_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```

--- a/4_integrations/1_mcp-remote/index.md
+++ b/4_integrations/1_mcp-remote/index.md
@@ -5,7 +5,7 @@ description: Connect external services to LM Studio via MCP.
 index: 1
 ---
 
-LM Studio now support MCP that use OAuth, letting you connect integrations that require authentication, no tokens to copy, no headers to configure. LM Studio opens a browser window, you log in, and the integration's tools become available to your models.
+LM Studio now supports MCP with OAuth. Seamlessly connect integrations that require authentication without copying tokens or configuring headers. Simply add your integration, log in via browser, and its tools are instantly available to your models in LM Studio.
 
 <img src="/assets/docs/mcp-auth.webp" style="width: 100%;" data-caption="Atlassian MCP logged in and Notion MCP requiring authentication" />
 

--- a/4_integrations/1_mcp-remote/popular.md
+++ b/4_integrations/1_mcp-remote/popular.md
@@ -39,7 +39,7 @@ Search pages, create documents, and read from your Notion workspace.
 
 
 <div className="w-fit">
-  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=notion&config=eyJ1cmwiOiJodHRwczovL2FwaS5ub3Rpb24uY29tL21jcCJ9">
+  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=notion&config=eyJ1cmwiOiJodHRwczovL21jcC5ub3Rpb24uY29tL21jcCJ9">
     <LightVariant>
       <img src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg" alt="Add Notion MCP to LM Studio" />
     </LightVariant>
@@ -53,7 +53,7 @@ Search pages, create documents, and read from your Notion workspace.
 {
   "mcpServers": {
     "notion": {
-      "url": "https://api.notion.com/mcp"
+      "url": "https://mcp.notion.com/mcp"
     }
   }
 }

--- a/4_integrations/1_mcp-remote/popular.md
+++ b/4_integrations/1_mcp-remote/popular.md
@@ -1,0 +1,123 @@
+---
+title: Popular MCP Integrations
+sidebar_title: Popular Integrations
+description: Connect popular services to LM Studio via MCP.
+index: 2
+---
+## Linear
+
+Create issues, search projects, update statuses, and more in Linear, directly from LM Studio.
+
+
+<div className="w-fit">
+  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=linear&config=eyJ1cmwiOiJodHRwczovL21jcC5saW5lYXIuYXBwL21jcCJ9">
+    <LightVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg" alt="Add Linear MCP to LM Studio" />
+    </LightVariant>
+    <DarkVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-dark.svg" alt="Add Linear MCP to LM Studio" />
+    </DarkVariant>
+  </a>
+</div>
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}
+```
+
+
+---
+
+## Notion
+
+Search pages, create documents, and read from your Notion workspace.
+
+
+<div className="w-fit">
+  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=notion&config=eyJ1cmwiOiJodHRwczovL2FwaS5ub3Rpb24uY29tL21jcCJ9">
+    <LightVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg" alt="Add Notion MCP to LM Studio" />
+    </LightVariant>
+    <DarkVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-dark.svg" alt="Add Notion MCP to LM Studio" />
+    </DarkVariant>
+  </a>
+</div>
+
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "url": "https://api.notion.com/mcp"
+    }
+  }
+}
+```
+
+
+---
+
+## Atlassian
+
+Work with Jira issues and Confluence pages from within LM Studio.
+
+
+<div className="w-fit">
+  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=atlassian&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL21jcCJ9">
+    <LightVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg" alt="Add Atlassian MCP to LM Studio" />
+    </LightVariant>
+    <DarkVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-dark.svg" alt="Add Atlassian MCP to LM Studio" />
+    </DarkVariant>
+  </a>
+</div>
+
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "url": "https://mcp.atlassian.com/mcp"
+    }
+  }
+}
+```
+
+
+---
+
+## Sentry
+
+Query issues, inspect stack traces, and analyze errors from your Sentry projects.
+
+
+<div className="w-fit">
+  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=sentry&config=eyJ1cmwiOiJodHRwczovL21jcC5zZW50cnkuZGV2L21jcCJ9">
+    <LightVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg" alt="Add Sentry MCP to LM Studio" />
+    </LightVariant>
+    <DarkVariant>
+      <img src="https://files.lmstudio.ai/deeplink/mcp-install-dark.svg" alt="Add Sentry MCP to LM Studio" />
+    </DarkVariant>
+  </a>
+</div>
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}
+```
+
+
+---
+
+Many more integrations are supported. Any MCP server that uses OAuth or standard HTTP transport can be connected to LM Studio. See [Use MCP Servers](/docs/app/mcp) for how to add custom servers manually via `mcp.json`.

--- a/4_integrations/1_mcp-remote/popular.md
+++ b/4_integrations/1_mcp-remote/popular.md
@@ -68,7 +68,7 @@ Work with Jira issues and Confluence pages from within LM Studio.
 
 
 <div className="w-fit">
-  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=atlassian&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL21jcCJ9">
+  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=atlassian&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL3YxL21jcCJ9">
     <LightVariant>
       <img src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg" alt="Add Atlassian MCP to LM Studio" />
     </LightVariant>
@@ -82,7 +82,7 @@ Work with Jira issues and Confluence pages from within LM Studio.
 {
   "mcpServers": {
     "atlassian": {
-      "url": "https://mcp.atlassian.com/mcp"
+      "url": "https://mcp.atlassian.com/v1/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add new page under Getting Started explaining the differences between the LM Studio desktop app, llmster (headless daemon), and lms (CLI)

## Test plan
- [ ] Verify page appears after "Chat with Documents" in the Getting Started sidebar
- [ ] Verify all links and code blocks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)