### PR TITLE
Fix missing MCP install buttons on popular integrations docs page

### DIFF
--- a/4_integrations/1_mcp-remote/popular.mdx
+++ b/4_integrations/1_mcp-remote/popular.mdx
@@ -10,7 +10,10 @@ Create issues, search projects, update statuses, and more in Linear, directly fr
 
 
 <div className="w-fit">
-  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=linear&config=eyJ1cmwiOiJodHRwczovL21jcC5saW5lYXIuYXBwL21jcCJ9">
+  <a
+    style={{ background: "rgb(255,255,255)" }}
+    href="https://lmstudio.ai/install-mcp?name=linear&config=eyJ1cmwiOiJodHRwczovL21jcC5saW5lYXIuYXBwL21jcCJ9"
+  >
     <img
       src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg"
       alt="Add Linear MCP to LM Studio"
@@ -43,7 +46,10 @@ Search pages, create documents, and read from your Notion workspace.
 
 
 <div className="w-fit">
-  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=notion&config=eyJ1cmwiOiJodHRwczovL21jcC5ub3Rpb24uY29tL21jcCJ9">
+  <a
+    style={{ background: "rgb(255,255,255)" }}
+    href="https://lmstudio.ai/install-mcp?name=notion&config=eyJ1cmwiOiJodHRwczovL21jcC5ub3Rpb24uY29tL21jcCJ9"
+  >
     <img
       src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg"
       alt="Add Notion MCP to LM Studio"
@@ -76,7 +82,10 @@ Work with Jira issues and Confluence pages from within LM Studio.
 
 
 <div className="w-fit">
-  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=atlassian&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL3YxL21jcCJ9">
+  <a
+    style={{ background: "rgb(255,255,255)" }}
+    href="https://lmstudio.ai/install-mcp?name=atlassian&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL3YxL21jcCJ9"
+  >
     <img
       src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg"
       alt="Add Atlassian MCP to LM Studio"
@@ -109,7 +118,10 @@ Query issues, inspect stack traces, and analyze errors from your Sentry projects
 
 
 <div className="w-fit">
-  <a style="background: rgb(255,255,255)" href="https://lmstudio.ai/install-mcp?name=sentry&config=eyJ1cmwiOiJodHRwczovL21jcC5zZW50cnkuZGV2L21jcCJ9">
+  <a
+    style={{ background: "rgb(255,255,255)" }}
+    href="https://lmstudio.ai/install-mcp?name=sentry&config=eyJ1cmwiOiJodHRwczovL21jcC5zZW50cnkuZGV2L21jcCJ9"
+  >
     <img
       src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg"
       alt="Add Sentry MCP to LM Studio"


### PR DESCRIPTION
Converted the MCP popular integrations page from .md to .mdx so its embedded JSX button markup is compiled correctly and the “Run in LM Studio” install buttons render again.

<img width="1557" height="1095" alt="Screenshot 2026-04-16 at 4 39 14 PM" src="https://github.com/user-attachments/assets/5955fe88-4b0e-4a44-987b-795cb31b4e78" />

<img width="349" height="488" alt="Screenshot 2026-04-16 at 4 40 51 PM" src="https://github.com/user-attachments/assets/f87c9e7d-31f9-4fa3-a6c3-fb1b4fc42638" />

