### PR TITLE
Fix broken OpenAI docs links in '1_developer/3_openai-compat/'

### DIFF
--- a/1_developer/3_openai-compat/chat-completions.md
+++ b/1_developer/3_openai-compat/chat-completions.md
@@ -9,7 +9,7 @@ api_info:
 - Method: `POST`
 - Prompt template is applied automatically for chat‑tuned models
 - Provide inference parameters (temperature, top_p, etc.) in the payload
-- See OpenAI docs: https://platform.openai.com/docs/api-reference/chat
+- See OpenAI docs: https://developers.openai.com/api/reference/chat-completions/overview
 - Tip: keep a terminal open with [`lms log stream`](/docs/cli/serve/log-stream) to inspect model input
 
 ##### Python example
@@ -32,7 +32,7 @@ print(completion.choices[0].message)
 
 ### Supported payload parameters
 
-See https://platform.openai.com/docs/api-reference/chat/create for parameter semantics.
+See https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create for parameter semantics.
 
 ```py
 model

--- a/1_developer/3_openai-compat/completions.mdx
+++ b/1_developer/3_openai-compat/completions.mdx
@@ -14,4 +14,4 @@ Using this endpoint with chat‑tuned models may produce unexpected tokens. Pref
 
 - Method: `POST`
 - Prompt template is not applied
-- See OpenAI docs: https://platform.openai.com/docs/api-reference/completions
+- See OpenAI docs: https://developers.openai.com/api/reference/resources/completions/methods/create

--- a/1_developer/3_openai-compat/embeddings.md
+++ b/1_developer/3_openai-compat/embeddings.md
@@ -7,7 +7,7 @@ api_info:
 ---
 
 - Method: `POST`
-- See OpenAI docs: https://platform.openai.com/docs/api-reference/embeddings
+- See OpenAI docs: https://developers.openai.com/api/reference/resources/embeddings/methods/create
 
 ##### Python example
 

--- a/1_developer/3_openai-compat/responses.md
+++ b/1_developer/3_openai-compat/responses.md
@@ -7,7 +7,7 @@ api_info:
 ---
 
 - Method: `POST`
-- See OpenAI docs: https://platform.openai.com/docs/api-reference/responses
+- See OpenAI docs: https://developers.openai.com/api/reference/responses/overview
 
 ##### cURL (non‑streaming)
 

--- a/1_developer/3_openai-compat/structured-output.md
+++ b/1_developer/3_openai-compat/structured-output.md
@@ -26,7 +26,7 @@ This will allow you to interact with LM Studio via the REST API. For an intro to
 
 The API supports structured JSON outputs through the `/v1/chat/completions` endpoint when given a [JSON schema](https://json-schema.org/overview/what-is-jsonschema). Doing this will cause the LLM to respond in valid JSON conforming to the schema provided.
 
-It follows the same format as OpenAI's recently announced [Structured Output](https://platform.openai.com/docs/guides/structured-outputs) API and is expected to work via the OpenAI client SDKs.
+It follows the same format as OpenAI's recently announced [Structured Output](https://developers.openai.com/api/docs/guides/structured-outputs) API and is expected to work via the OpenAI client SDKs.
 
 **Example using `curl`**
 

--- a/1_developer/3_openai-compat/tools.mdx
+++ b/1_developer/3_openai-compat/tools.mdx
@@ -102,7 +102,7 @@ Tool use describes:
 
 LM Studio supports tool use through the `/v1/chat/completions` endpoint when given function definitions in the `tools` parameter of the request body. Tools are specified as an array of function definitions that describe their parameters and usage, like:
 
-It follows the same format as OpenAI's [Function Calling](https://platform.openai.com/docs/guides/function-calling) API and is expected to work via the OpenAI client SDKs.
+It follows the same format as OpenAI's [Function Calling](https://developers.openai.com/api/docs/guides/function-calling) API and is expected to work via the OpenAI client SDKs.
 
 We will use [lmstudio-community/Qwen2.5-7B-Instruct-GGUF](https://model.lmstudio.ai/download/lmstudio-community/Qwen2.5-7B-Instruct-GGUF) as the model in this example flow.
 


### PR DESCRIPTION
# Fix broken OpenAI docs links in `1_developer/3_openai-compat/`

## Summary
OpenAI moved its developer documentation from [platform.openai.com/docs/](https://platform.openai.com/docs/api-reference/) to [developers.openai.com/api/docs/](https://developers.openai.com/api/docs). The old URLs no longer resolve, so every "See OpenAI docs" link in `1_developer/3_openai-compat/` is currently broken.

This PR remaps all affected links to their verified equivalents on the new domain.