### PR TITLE
Mention disabling attribution header in claude code

### DIFF
--- a/4_integrations/claude-code.mdx
+++ b/4_integrations/claude-code.mdx
@@ -38,6 +38,7 @@ Have a powerful LLM rig? Use [LM Link](/docs/integrations/lmlink) to run Claude 
     ```bash
     export ANTHROPIC_BASE_URL=http://localhost:1234
     export ANTHROPIC_AUTH_TOKEN=lmstudio
+    export CLAUDE_CODE_ATTRIBUTION_HEADER=0
     ```
 
     Notes:


### PR DESCRIPTION
## Overview

To avoid dropping cache for every request, the env variable `CLAUDE_CODE_ATTRIBUTION_HEADER=0` is recommended