### PR TITLE
Add Exa to popular MCP integrations

### DIFF
--- a/4_integrations/1_mcp-remote/popular.mdx
+++ b/4_integrations/1_mcp-remote/popular.mdx
@@ -148,4 +148,40 @@ Query issues, inspect stack traces, and analyze errors from your Sentry projects
 
 ---
 
+## Exa
+
+Search the web, fetch page contents, and research companies, people, or code using [Exa](https://exa.ai), an AI-native search engine.
+
+
+<div className="w-fit">
+  <a
+    style={{ background: "rgb(255,255,255)" }}
+    href="https://lmstudio.ai/install-mcp?name=exa&config=eyJ1cmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0%3D"
+  >
+    <img
+      src="https://files.lmstudio.ai/deeplink/mcp-install-light.svg"
+      alt="Add Exa MCP to LM Studio"
+      className="dark:hidden"
+    />
+    <img
+      src="https://files.lmstudio.ai/deeplink/mcp-install-dark.svg"
+      alt="Add Exa MCP to LM Studio"
+      className="hidden dark:block"
+    />
+  </a>
+</div>
+
+```json
+{
+  "mcpServers": {
+    "exa": {
+      "url": "https://mcp.exa.ai/mcp"
+    }
+  }
+}
+```
+
+
+---
+
 Many more integrations are supported. Any MCP server that uses OAuth or standard HTTP transport can be connected to LM Studio. See [Use MCP Servers](/docs/app/mcp) for how to add custom servers manually via `mcp.json`.


### PR DESCRIPTION
Adds [Exa](https://exa.ai) to the Popular MCP Integrations page.

Exa is an AI-native search engine used by Cursor, Claude, Codex, and many agent frameworks. The hosted MCP server at `https://mcp.exa.ai/mcp` provides web search, content fetching, and research tools with OAuth support.

The entry follows the exact same format as the existing Linear, Notion, Atlassian, and Sentry entries:
- One-click install button (light + dark variants)
- Manual `mcp.json` config snippet
- One-line description

Hi! I am an engineer from [Exa](https://exa.ai). We would love to be listed as a popular MCP integration in LM Studio. Our hosted MCP server works out of the box with LM Studio 0.3.17+ and requires no API key for the free tier.